### PR TITLE
Add profile route with safe rendering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,12 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import './globals.css';
 import SigninForm from './_auth/forms/SigninForm';
-import { Home } from './_root/pages';
+import { Home, Profile } from './_root/pages';
 import SignupForm from './_auth/forms/SignupForm';
 import AuthLayout from './_auth/AuthLayout';
 import RootLayout from './_root/RootLayout';
 
 import { Toaster } from "@/components/ui/toaster"
-
-
 
 const App = () => {
   return (
@@ -19,15 +17,14 @@ const App = () => {
           <Route path="/sign-in" element={<SigninForm />} />
           <Route path="/sign-up" element={<SignupForm />} />
         </Route>
-        
+
         {/* private routes */}
         <Route element={<RootLayout />}>
           <Route index element={<Home />} />
-
+          <Route path="/profile/:id" element={<Profile />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
         </Route>
-        
-
-      </Routes>  
+      </Routes>
       <Toaster />
     </main>
   )

--- a/src/_root/RootLayout.tsx
+++ b/src/_root/RootLayout.tsx
@@ -1,9 +1,13 @@
-
+import { Outlet } from 'react-router-dom';
 
 const RootLayout = () => {
   return (
-    <div>RootLayout</div>
-  )
-}
+    <main className="flex min-h-screen bg-slate-50 text-slate-900">
+      <section className="flex-1">
+        <Outlet />
+      </section>
+    </main>
+  );
+};
 
-export default RootLayout
+export default RootLayout;

--- a/src/_root/pages/Home.tsx
+++ b/src/_root/pages/Home.tsx
@@ -1,8 +1,9 @@
-
 const Home = () => {
   return (
-    <div>Home</div>
-  )
-}
+    <section className="p-6">
+      <h1 className="text-2xl font-semibold">Home</h1>
+    </section>
+  );
+};
 
-export default Home
+export default Home;

--- a/src/_root/pages/Profile.tsx
+++ b/src/_root/pages/Profile.tsx
@@ -1,0 +1,51 @@
+import { useLocation, useParams } from 'react-router-dom';
+
+interface ProfileState {
+  name?: string;
+  posts?: Array<{
+    id?: string;
+    caption?: string;
+    location?: string;
+  }>;
+}
+
+const Profile = () => {
+  const { id } = useParams();
+  const { state } = useLocation() as { state?: ProfileState };
+
+  const posts = Array.isArray(state?.posts) ? state?.posts : [];
+  const displayName = state?.name ?? id ?? 'Profile';
+
+  return (
+    <section className="mx-auto flex max-w-4xl flex-col gap-6 p-6">
+      <header className="border-b border-slate-200 pb-4">
+        <h1 className="text-3xl font-semibold">{displayName}</h1>
+        <p className="text-sm text-slate-500">
+          {posts.length === 1 ? 'Showing 1 post' : `Showing ${posts.length} posts`}
+        </p>
+      </header>
+
+      {posts.length === 0 ? (
+        <p className="text-slate-500">This profile has not shared any posts yet.</p>
+      ) : (
+        <ul className="flex flex-col gap-4">
+          {posts.map((post, index) => (
+            <li
+              key={post.id ?? index}
+              className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+            >
+              <p className="font-medium text-slate-900">
+                {post.caption?.trim() || 'Untitled post'}
+              </p>
+              {post.location && (
+                <p className="text-sm text-slate-500">Location: {post.location}</p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+export default Profile;

--- a/src/_root/pages/index.ts
+++ b/src/_root/pages/index.ts
@@ -1,1 +1,2 @@
 export { default as Home } from './Home';
+export { default as Profile } from './Profile';


### PR DESCRIPTION
## Summary
- add a profile route and page that safely renders posts without crashing
- update the root layout and home page so nested routes render correctly
- add a catch-all redirect to keep navigation from showing a blank screen

## Testing
- `npm run build` *(fails: npm registry access is blocked so react-router-dom cannot be installed in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693b0986b59c83309943ef04b1ef6850)